### PR TITLE
Feat: 로그인 API 구현

### DIFF
--- a/segorang-server/model/mysql/user.py
+++ b/segorang-server/model/mysql/user.py
@@ -34,6 +34,9 @@ class User(Model):
             condition=f"WHERE {property}={set_quote(input_property)}"
         )
         self.cursor.execute(query)
-
-        return self.cursor.fetchone()
+        user_data = self.cursor.fetchone()
+        if user_data is None:
+            return None
+        else:
+            return dict(zip(self.property, user_data))
 


### PR DESCRIPTION
- 로그인 API 구현
- 회원가입 API에서 반환하는 access_token, refresh_token 제거
- 모델 단의 User의 get_user_by_single_property 메소드에서
  기존의 삽입한 값을 튜플로 제공하던 것을 
    -> 값이 없을 경우 None,
    -> 값이 있을 경우 Dict로 감싸서 반환
  